### PR TITLE
Backend/#25/record api

### DIFF
--- a/frontend/src/component/history/history.js
+++ b/frontend/src/component/history/history.js
@@ -2,15 +2,48 @@ import './history.scss';
 import { createEl } from '../../utils/createElement';
 import { appendArray } from '../../utils/handleElement';
 import { div, input, select, option } from '../../utils/element';
+import api from '../../utils/api';
 
 
 export class History {
     constructor() {
         this.historySection = createEl('div', 'history-section', '', {});
+        this.getData();
+    }
 
+    // 아직 모델이 안만들어져 있어서 모델에서 History 컴포넌트에 데이터를 주입하는 역할을 한다. 추후 삭제 예정
+    async getData() {
+        const data = await api.get('http://localhost:3000/api/transaction/abc@abc.com/7').then(res => res.json());
+        this.setData(data);
+
+        const result = [];
+        let oneDay;
+        let preDate = -1000;
+        data.forEach(one => {
+            const oneDate = new Date(one.paymentAt);
+            if (preDate !== oneDate.getDate()) {
+                oneDay = {
+                    paymentAt: one.paymentAt,
+                    totalIncome: 0,
+                    totalOutcome: 0,
+                    items: [],
+                };
+                preDate = oneDate.getDate();
+                result.push(oneDay);
+            }
+            const { categoryType, name, money, content } = one;
+            if (categoryType === "지출") {
+                oneDay.totalOutcome += parseInt(money);
+            } else {
+                oneDay.totalIncome += parseInt(money);
+            }
+            oneDay.items.push({ categoryType, name, money, content });
+        });
+        return result;
     }
 
     setData(data) {
+        console.log("adf", data);
         this.data = data;
     }
 
@@ -18,57 +51,47 @@ export class History {
         this.historySection.innerHTML = '';
     }
 
-    createHistoryWrap() {
-        const historyWrap = div({ className: 'history-wrap' },
-            div({ className: 'history' },
-                div({ className: 'history-day-info line' },
-                    div({ className: 'history-day' }, '8월 2일 일'),
-                    div({ className: 'date-money-wrap' },
-                        div({ className: 'day-income' }, '+0원'),
-                        div({ className: 'day-outcome' }, '-20000원'))),
-                div({ className: 'history-day-list-wrap' },
-                    div({ className: 'history-day-item line' },
-                        div({ className: 'history-day-item-left' },
-                            div({ className: 'history-day-income-category' }, '쇼핑/뷰티'),
-                            div({ className: 'history-day-content' }, '헤어샵')),
-                        div({ className: 'history-repair' }, '수정'),
-                        div({ className: 'history-day-item-right' },
-                            div({ className: 'payment' }, '현대카드'),
-                            div({ className: 'income-money' }, '-20,000원'))))
-            ),
-            div({ className: 'history' },
-                div({ className: 'history-day-info line' },
-                    div({ className: 'history-day' }, '8월 3일 월'),
-                    div({ className: 'date-money-wrap' },
-                        div({ className: 'day-income' }, '+90,000원'),
-                        div({ className: 'day-outcome' }, '0원'))),
-                div({ className: 'history-day-list-wrap' },
-                    div({ className: 'history-day-item line' },
-                        div({ className: 'history-day-item-left' },
-                            div({ className: 'history-day-outcome-category' }, '월급'),
-                            div({ className: 'history-day-content' }, '월급')),
-                        div({ className: 'history-repair' }, '수정'),
-                        div({ className: 'history-day-item-right' },
-                            div({ className: 'payment' }, '삼성카드'),
-                            div({ className: 'outcome-money' }, '+40,000원'))),
-                    div({ className: 'history-day-item line' },
-                        div({ className: 'history-day-item-left' },
-                            div({ className: 'history-day-outcome-category' }, '용돈'),
-                            div({ className: 'history-day-content' }, '용돈')),
-                        div({ className: 'history-repair' }, '수정'),
-                        div({ className: 'history-day-item-right' },
-                            div({ className: 'payment' }, '국민은행'),
-                            div({ className: 'outcome-money' }, '+50,000원'))))
-            ));
+    async createHistoryWrap(data1) {
+        const data = await this.getData();
+        console.log(data);
+
+        const rr = data.map(one => this.createOneDate(one))
+        const historyWrap = div({ className: 'history-wrap' });
+        appendArray(historyWrap, rr);
         return historyWrap;
     }
 
-    createHistory() {
-        appendArray(this.historySection, [this.createHistoryWrap()]);
+    createOneDate(data) {
+        return div({ className: 'history' },
+            div({ className: 'history-day-info line' },
+                div({ className: 'history-day' }, data.paymentAt),
+                div({ className: 'date-money-wrap' },
+                    div({ className: 'day-income' }, data.totalIncome),
+                    div({ className: 'day-outcome' }, data.totalOutcome))),
+
+            div({ className: 'history-day-list-wrap' },
+                ...data.items.map(item => this.createOneDateDetail(item))
+            )
+        );
+    }
+
+    createOneDateDetail(detailData) {
+        return div({ className: 'history-day-item line' },
+            div({ className: 'history-day-item-left' },
+                div({ className: `history-day-${detailData.categoryType === "수입" ? "income" : "outcome"}-category` }, '쇼핑/뷰티'), // 카테고리
+                div({ className: 'history-day-content' }, detailData.content)),           // 컨텐츠
+            div({ className: 'history-repair' }, '수정'),
+            div({ className: 'history-day-item-right' },
+                div({ className: 'payment' }, detailData.name),                      // 결제수단
+                div({ className: `${detailData.categoryType === "수입" ? "income" : "outcome"}-money` }, detailData.money)));            // 금액
+    }
+
+    async createHistory() {
+        const historyWrap = await this.createHistoryWrap();
+        this.historySection.appendChild(historyWrap);
     }
 
     render() {
-        // return this.baseElement;
         this.reset();
         this.createHistory();
 

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,0 +1,43 @@
+
+export default {
+    get: function (url, data) {
+        return fetch(url, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(data)
+        })
+
+    },
+    post: function (url, data) {
+        return fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(data)
+        })
+
+    },
+    put: function (url, data) {
+        return fetch(url, {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(data)
+        })
+
+    },
+    delete: function (url, data) {
+        return fetch(url, {
+            method: 'DELETE',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(data)
+        })
+
+    }
+}

--- a/frontend/src/utils/handleElement.js
+++ b/frontend/src/utils/handleElement.js
@@ -14,6 +14,7 @@ export function appendText(element, text) {
 }
 
 export function appendArray(element, children) {
+
     children.forEach((child) => {
         if (Array.isArray(child)) {
             appendArray(element, child);

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -3,6 +3,7 @@ import path from "path";
 import loginRouter from "./login/loginRouter";
 import authRouter from "./auth/authRouter";
 import userRouter from "./user/userRouter";
+import transactionRouter from "./record/recordRouter";
 
 const router = express.Router();
 const PUBLIC_PATH = path.join(__dirname, "..", "public");
@@ -10,8 +11,9 @@ const PUBLIC_PATH = path.join(__dirname, "..", "public");
 router.get("/", (req, res, next) => {
     res.sendFile(path.join(PUBLIC_PATH, "index.html"));
 });
-router.use("/login", loginRouter);
-router.use("/auth", authRouter);
-router.use("/user", userRouter);
+router.use("/api/login", loginRouter);
+router.use("/api/auth", authRouter);
+router.use("/api/user", userRouter);
+router.use("/api/transaction", transactionRouter);
 
 export default router;

--- a/server/src/api/record/recordController.ts
+++ b/server/src/api/record/recordController.ts
@@ -1,0 +1,14 @@
+import { Request, Response, NextFunction } from "express";
+import query from "../../db/query";
+import db from "../../db/mysql";
+
+export default {
+    getMonthRecord: async function (req: Request, res: Response, next: NextFunction) {
+        const { email, month } = req.params;
+        const records = await db.selectData(query.SELECT_RECORD_INFO, [email, month]);
+        console.log(records);
+        res.status(200).json(records);
+    },
+    addRecord: async function () {},
+    modifyRecord: async function () {},
+};

--- a/server/src/api/record/recordRouter.ts
+++ b/server/src/api/record/recordRouter.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import recordController from "./recordController";
+
+const router = Router();
+
+router.get("/:email/:month", recordController.getMonthRecord);
+
+export default router;

--- a/server/src/db/query.ts
+++ b/server/src/db/query.ts
@@ -66,15 +66,20 @@ const CREATE_RECORD_TB = `
     );
 `;
 
-const INSERT_RECORD_TB = `INSERT INTO record_tb(payment_at, category_no, payment_method_no, money, content) VALUES(?, ?, ?, ?, ?);`;
+const INSERT_RECORD_TB = `INSERT INTO record_tb(payment_at, member_no, category_no, payment_method_no, money, content) VALUES(?, ?, ?, ?, ?, ?);`;
+const UPDATE_RECORD_TB = `
+    UPDATE record_tb
+    SET payment_at=?, member_no=?, category_no=?, payment_method_no=?, money=?, content=?, is_deleted=?
+    where no = ?;
+`;
 
 const SELECT_RECORD_INFO = `
-    select payment_at, member_tb.email, category_tb.type, category_tb.name, payment_method_tb.name, money, content 
+    select payment_at as paymentAt, member_tb.email, category_tb.type as categoryType, category_tb.name, payment_method_tb.name, money, content 
     from record_tb
         INNER JOIN member_tb on record_tb.member_no = member_tb.no
         inner join payment_method_tb on payment_method_tb.no = record_tb.payment_method_no
         inner join category_tb on category_tb.no = record_tb.category_no
-    where member_tb.no = ? 
+    where member_tb.email = ? 
         AND record_tb.is_deleted = 0
         AND category_tb.is_deleted = 0
         AND payment_method_tb.is_deleted = 0

--- a/server/src/db/query.ts
+++ b/server/src/db/query.ts
@@ -84,7 +84,7 @@ const SELECT_RECORD_INFO = `
         AND category_tb.is_deleted = 0
         AND payment_method_tb.is_deleted = 0
         AND month(record_tb.payment_at) = ?
-    order by payment_at desc;
+    order by record_tb.payment_at desc;
 `;
 
 const RESET_TB = `delete from ?`;


### PR DESCRIPTION
백엔드에서 데이터 가져오는 API를 생성함.
```
GET : /api/transactioin/:email/:month

response : JSON 
{ 
  categoryType: string
  content: string
  email: string
  money: string
  name: string
  paymentAt: string
}
```


거래내역에서 각각의 날짜에 대해서 수익과 매출에 대한 데이터 매칭
하드코딩되어 있던 부분을 데이터 매칭 및 자동화
뷰에 적절하게 데이터 가공

```
{
paymentAt, totalIncome, totaloutcome,
items: [ {categoryType, name(은행이름), money, content}, ...],
}
```
스타일을 위한 클래스 네이밍 분리
frontend영역 api 추가 (get, post, put, delete 유틸 메서드 추가)