### PR TITLE
Fullstack/#32/history add 

### DIFF
--- a/frontend/src/component/body/input/input.js
+++ b/frontend/src/component/body/input/input.js
@@ -1,7 +1,7 @@
 import './input.scss';
 import { createEl } from '../../../utils/createElement';
 import { appendArray } from '../../../utils/handleElement';
-import { clickDeleteInputInfoBtn, clickIncomeBtn, clickOutcomeBtn } from './inputHandler.js';
+import { clickDeleteInputInfoBtn, clickIncomeBtn, clickOutcomeBtn, keyupMoneyInput } from './inputHandler.js';
 import { div, input, select, option } from '../../../utils/element';
 import { func } from './inputHandler';
 
@@ -31,7 +31,7 @@ export class Input {
                 div({ className: 'input-middle' },
                     div({ className: 'input-date-wrap wrap' },
                         div({ className: 'input-date-title title' }, '날짜'),
-                        input({ className: 'input-date-text text' })),
+                        input({ className: 'input-date-text text', type: 'date' })),
                     div({ className: 'input-category-wrap wrap' },
                         div({ className: 'input-category-title title' }, '카테고리'),
                         select({ className: 'input-category-select select' },
@@ -48,7 +48,7 @@ export class Input {
                 div({ className: 'input-bottom' },
                     div({ className: 'input-money-wrap wrap' },
                         div({ className: 'input-money-title title' }, '금액'),
-                        input({ className: 'input-money-text text' })),
+                        input({ className: 'input-money-text text', onkeyup: keyupMoneyInput, placeholder: 0 })),
                     div({ className: 'input-content-wrap wrap' },
                         div({ className: 'input-content-title title' }, '내용'),
                         input({ className: 'input-content-text text' })))),

--- a/frontend/src/component/body/input/input.js
+++ b/frontend/src/component/body/input/input.js
@@ -15,11 +15,14 @@ export class Input {
     setData(data) {
         this.data = data;
     }
-    getPaymentMethodData() {
+    async getPaymentMethodData() {
+        const paymentMethods = await api.get("http://localhost:3000/api/payment/method/1").then(res => res.json());
+        this.paymentMethods = paymentMethods;
 
     }
 
     reset() {
+        this.paymentMethods;
         this.inputSection.innerHTML = '';
     }
 
@@ -56,9 +59,7 @@ export class Input {
                     div({ className: 'input-payment-select-wrap wrap' },
                         div({ className: 'input-payment-select-title title' }, '결제수단'),
                         select({ className: 'input-payment-select select' },
-                            option({ className: 'option-list' }, '선택해주세요'),
-                            option({ className: 'option-list' }, '선택해주세요'),
-                            option({ className: 'option-list' }, '선택해주세요'),
+                            ...this.createSelectOptions(this.paymentMethods)
                         ))),
                 div({ className: 'input-bottom' },
                     div({ className: 'input-money-wrap wrap' },
@@ -73,19 +74,19 @@ export class Input {
     }
     createSelectOptions(data) {
         const result = [option({ className: 'option-list', select: true, disable: true, hidden: true }, '선택해주세요')];
-        const options = data.map(o => option({ className: 'option-list', value: data.no }, o.name));
+        const options = data.map(o => option({ className: 'option-list', value: data.no }, o.paymentMethodName));
         result.push(...options);
         return result;
     }
 
-    createInput() {
-        const inputBoxWrap = this.createInputBoxWrap();
-        // console.log(inputBoxWrap);
+    async createInput() {
+        await this.getPaymentMethodData();
+        const inputBoxWrap = await this.createInputBoxWrap();
         appendArray(this.inputSection, [inputBoxWrap]);
     }
 
     render() {
-        // return this.baseElement;
+        this.getPaymentMethodData();
         this.reset();
         this.createInput();
 

--- a/frontend/src/component/body/input/input.js
+++ b/frontend/src/component/body/input/input.js
@@ -1,7 +1,7 @@
 import './input.scss';
 import { createEl } from '../../../utils/createElement';
 import { appendArray } from '../../../utils/handleElement';
-import { clickDeleteInputInfoBtn, clickIncomeBtn, clickOutcomeBtn, keyupMoneyInput } from './inputHandler.js';
+import { clickDeleteInputInfoBtn, clickIncomeBtn, clickOutcomeBtn, keyupMoneyInput, clickSubmitBtn } from './inputHandler.js';
 import { div, input, select, option } from '../../../utils/element';
 import { func } from './inputHandler';
 import api from '../../../utils/api';
@@ -42,12 +42,12 @@ export class Input {
                     div({ className: 'input-category-wrap wrap' },
                         div({ className: 'input-category-title title' }, '카테고리'),
                         select({ className: 'input-category-select income-select select' },
-                            option({ className: 'option-list', select: true, disable: true, hidden: true }, '선택해주세요'),
+                            option({ className: 'option-list', selected: true, disabled: true, hidden: true }, '선택해주세요'),
                             option({ className: 'option-list', value: "1" }, '월급'),
                             option({ className: 'option-list', value: "2" }, '용돈'),
                             option({ className: 'option-list', value: "3" }, '기타수입')),
                         select({ className: 'input-category-select outcome-select select hidden' },
-                            option({ className: 'option-list', select: true, disable: true, hidden: true }, '선택해주세요'),
+                            option({ className: 'option-list', selected: true, disabled: true, hidden: true }, '선택해주세요'),
                             option({ className: 'option-list', value: "4" }, '식비'),
                             option({ className: 'option-list', value: "5" }, '생활'),
                             option({ className: 'option-list', value: "6" }, '쇼핑/뷰티'),
@@ -58,7 +58,7 @@ export class Input {
                     ),
                     div({ className: 'input-payment-select-wrap wrap' },
                         div({ className: 'input-payment-select-title title' }, '결제수단'),
-                        select({ className: 'input-payment-select select' },
+                        select({ className: 'input-payment-select payment-method-select select' },
                             ...this.createSelectOptions(this.paymentMethods)
                         ))),
                 div({ className: 'input-bottom' },
@@ -68,25 +68,28 @@ export class Input {
                     div({ className: 'input-content-wrap wrap' },
                         div({ className: 'input-content-title title' }, '내용'),
                         input({ className: 'input-content-text text' })))),
-            div({ className: 'input-submit-btn' }, '확 인'));
+            div({ className: 'input-submit-btn', onclick: clickSubmitBtn }, '확 인'));
 
         return InputBoxWrap;
     }
+    submitHandler() {
+
+    }
+
     createSelectOptions(data) {
-        const result = [option({ className: 'option-list', select: true, disable: true, hidden: true }, '선택해주세요')];
-        const options = data.map(o => option({ className: 'option-list', value: data.no }, o.paymentMethodName));
+        const result = [option({ className: 'option-list', selected: true, disabled: true, hidden: true }, '선택해주세요')];
+        const options = data.map(o => option({ className: 'option-list', value: o.no }, o.paymentMethodName));
         result.push(...options);
         return result;
     }
 
     async createInput() {
         await this.getPaymentMethodData();
-        const inputBoxWrap = await this.createInputBoxWrap();
+        const inputBoxWrap = this.createInputBoxWrap();
         appendArray(this.inputSection, [inputBoxWrap]);
     }
 
     render() {
-        this.getPaymentMethodData();
         this.reset();
         this.createInput();
 

--- a/frontend/src/component/body/input/input.js
+++ b/frontend/src/component/body/input/input.js
@@ -4,6 +4,7 @@ import { appendArray } from '../../../utils/handleElement';
 import { clickDeleteInputInfoBtn, clickIncomeBtn, clickOutcomeBtn, keyupMoneyInput } from './inputHandler.js';
 import { div, input, select, option } from '../../../utils/element';
 import { func } from './inputHandler';
+import api from '../../../utils/api';
 
 
 export class Input {
@@ -13,6 +14,9 @@ export class Input {
     }
     setData(data) {
         this.data = data;
+    }
+    getPaymentMethodData() {
+
     }
 
     reset() {
@@ -25,7 +29,7 @@ export class Input {
                 div({ className: 'input-top' },
                     div({ className: 'classification-wrap wrap' },
                         div({ className: 'classification-title title' }, '분류'),
-                        div({ className: 'classification-income classification-btn', onclick: clickIncomeBtn }, '수입'),
+                        div({ className: 'classification-income classification-btn clicked', onclick: clickIncomeBtn }, '수입'),
                         div({ className: 'classification-outcome classification-btn', onclick: clickOutcomeBtn }, '지출')),
                     div({ className: 'delete-input-info-btn', onclick: clickDeleteInputInfoBtn }, '내용 지우기')),
                 div({ className: 'input-middle' },
@@ -34,10 +38,21 @@ export class Input {
                         input({ className: 'input-date-text text', type: 'date' })),
                     div({ className: 'input-category-wrap wrap' },
                         div({ className: 'input-category-title title' }, '카테고리'),
-                        select({ className: 'input-category-select select' },
-                            option({ className: 'option-list' }, '선택해주세요'),
-                            option({ className: 'option-list' }, '선택해주세요'),
-                            option({ className: 'option-list' }, '선택해주세요'))),
+                        select({ className: 'input-category-select income-select select' },
+                            option({ className: 'option-list', select: true, disable: true, hidden: true }, '선택해주세요'),
+                            option({ className: 'option-list', value: "1" }, '월급'),
+                            option({ className: 'option-list', value: "2" }, '용돈'),
+                            option({ className: 'option-list', value: "3" }, '기타수입')),
+                        select({ className: 'input-category-select outcome-select select hidden' },
+                            option({ className: 'option-list', select: true, disable: true, hidden: true }, '선택해주세요'),
+                            option({ className: 'option-list', value: "4" }, '식비'),
+                            option({ className: 'option-list', value: "5" }, '생활'),
+                            option({ className: 'option-list', value: "6" }, '쇼핑/뷰티'),
+                            option({ className: 'option-list', value: "7" }, '교통'),
+                            option({ className: 'option-list', value: "8" }, '의료/건강'),
+                            option({ className: 'option-list', value: "9" }, '문화/여가'),
+                            option({ className: 'option-list', value: "10" }, '미분류'))
+                    ),
                     div({ className: 'input-payment-select-wrap wrap' },
                         div({ className: 'input-payment-select-title title' }, '결제수단'),
                         select({ className: 'input-payment-select select' },
@@ -55,6 +70,12 @@ export class Input {
             div({ className: 'input-submit-btn' }, '확 인'));
 
         return InputBoxWrap;
+    }
+    createSelectOptions(data) {
+        const result = [option({ className: 'option-list', select: true, disable: true, hidden: true }, '선택해주세요')];
+        const options = data.map(o => option({ className: 'option-list', value: data.no }, o.name));
+        result.push(...options);
+        return result;
     }
 
     createInput() {

--- a/frontend/src/component/body/input/input.scss
+++ b/frontend/src/component/body/input/input.scss
@@ -47,6 +47,7 @@
               border-radius: 4px;
             cursor: pointer;
 
+            
           }
         }
         .delete-input-info-btn {
@@ -139,4 +140,12 @@
       cursor: pointer;
     }
   }
+}
+
+.hidden {
+  display:none;
+}
+
+.clicked {
+  background-color: #000;
 }

--- a/frontend/src/component/body/input/inputHandler.js
+++ b/frontend/src/component/body/input/inputHandler.js
@@ -1,11 +1,27 @@
-export const clickDeleteInputInfoBtn = function(e) {
+export const clickDeleteInputInfoBtn = function (e) {
     // console.log(e);
 };
 
-export const clickIncomeBtn = function(e) {
+export const clickIncomeBtn = function (e) {
     // console.log(e);
 };
 
-export const clickOutcomeBtn = function(e) {
+export const clickOutcomeBtn = function (e) {
     // console.log(e);
 };
+
+const TEXT_LENGTH = 15;
+export const keyupMoneyInput = function (e) {
+
+    let numText = (e.target.value).match(/\d+/g);
+    if (numText) {
+        numText = +numText.join("").substring(0, TEXT_LENGTH);
+    }
+    e.target.value = numText ? numberFormat(numText) : "";
+}
+
+const numberFormatkoKr = new Intl.NumberFormat('ko-KR', { maximumSignificantDigits: 14 });
+
+function numberFormat(num) {
+    return numberFormatkoKr.format(num);
+}

--- a/frontend/src/component/body/input/inputHandler.js
+++ b/frontend/src/component/body/input/inputHandler.js
@@ -1,8 +1,47 @@
+let inputClassification = "수입";
+let inputMoney;
+
+
+export const clickSubmitBtn = function (e) {
+    // 결제 날짜
+    const dateText = document.querySelector('.input-date-text').value;
+    if (!dateText) return alert("날짜가 제대로 입력되지 않았습니다.");
+
+    // 카테고리
+    const category = (inputClassification === '수입')
+        ? document.querySelector('.income-select').value
+        : document.querySelector('.outcome-select').value;
+
+    if (category === "선택해주세요") return alert("카테고리를 선택해 주세요");
+
+    // 결제 수단
+    const paymentMethod = document.querySelector('.payment-method-select').value;
+    if (paymentMethod === "선택해주세요") return alert("결제 수단을 선택해 주세요");
+
+    // money
+    const money = parseInt(inputMoney);
+    if (money <= 0 || Number.isNaN(money)) return alert("금액을 입력해 주세요");
+
+    // 내용
+    const content = document.querySelector('.input-content-text').value.trim();
+    if (!content) return alert("내용을 입력해 주세요");
+
+    const result = { dateText, category, paymentMethod, money, content };
+    console.log(result);
+
+    // api로 보내기
+
+    // 그 이후 결과값 받기
+
+    // 모델에 보내야 함. 
+}
+
 export const clickDeleteInputInfoBtn = function (e) {
     // console.log(e);
 };
 
 export const clickIncomeBtn = function (e) {
+    inputClassification = "수입";
 
     e.target.classList.add('clicked');
     document.querySelector('.classification-outcome').classList.remove('clicked');
@@ -14,6 +53,8 @@ export const clickIncomeBtn = function (e) {
 };
 
 export const clickOutcomeBtn = function (e) {
+    inputClassification = "지출";
+
     e.target.classList.add('clicked');
     document.querySelector('.classification-income').classList.remove('clicked');
 
@@ -30,6 +71,7 @@ export const keyupMoneyInput = function (e) {
     if (numText) {
         numText = +numText.join("").substring(0, TEXT_LENGTH);
     }
+    inputMoney = numText;
     e.target.value = numText ? numberFormat(numText) : "";
 }
 

--- a/frontend/src/component/body/input/inputHandler.js
+++ b/frontend/src/component/body/input/inputHandler.js
@@ -3,11 +3,24 @@ export const clickDeleteInputInfoBtn = function (e) {
 };
 
 export const clickIncomeBtn = function (e) {
-    // console.log(e);
+
+    e.target.classList.add('clicked');
+    document.querySelector('.classification-outcome').classList.remove('clicked');
+
+    const incomeSelect = document.querySelector('.income-select');
+    incomeSelect.classList.remove('hidden');
+    const outcomeSelect = document.querySelector('.outcome-select');
+    outcomeSelect.classList.add('hidden');
 };
 
 export const clickOutcomeBtn = function (e) {
-    // console.log(e);
+    e.target.classList.add('clicked');
+    document.querySelector('.classification-income').classList.remove('clicked');
+
+    const incomeSelect = document.querySelector('.income-select');
+    incomeSelect.classList.add('hidden');
+    const outcomeSelect = document.querySelector('.outcome-select');
+    outcomeSelect.classList.remove('hidden');
 };
 
 const TEXT_LENGTH = 15;
@@ -20,8 +33,9 @@ export const keyupMoneyInput = function (e) {
     e.target.value = numText ? numberFormat(numText) : "";
 }
 
-const numberFormatkoKr = new Intl.NumberFormat('ko-KR', { maximumSignificantDigits: 14 });
+const numberFormatkoKr = new Intl.NumberFormat('ko-KR');
 
 function numberFormat(num) {
     return numberFormatkoKr.format(num);
 }
+

--- a/frontend/src/component/history/history.js
+++ b/frontend/src/component/history/history.js
@@ -31,13 +31,13 @@ export class History {
                 preDate = oneDate.getDate();
                 result.push(oneDay);
             }
-            const { categoryType, name, money, content } = one;
+            const { categoryType, categoryName, paymentMethodName, money, content } = one;
             if (categoryType === "지출") {
                 oneDay.totalOutcome += parseInt(money);
             } else {
                 oneDay.totalIncome += parseInt(money);
             }
-            oneDay.items.push({ categoryType, name, money, content });
+            oneDay.items.push({ categoryType, categoryName, paymentMethodName, money, content });
         });
         return result;
     }
@@ -78,11 +78,11 @@ export class History {
     createOneDateDetail(detailData) {
         return div({ className: 'history-day-item line' },
             div({ className: 'history-day-item-left' },
-                div({ className: `history-day-${detailData.categoryType === "수입" ? "income" : "outcome"}-category` }, '쇼핑/뷰티'), // 카테고리
+                div({ className: `history-day-${detailData.categoryType === "수입" ? "income" : "outcome"}-category` }, detailData.categoryName), // 카테고리
                 div({ className: 'history-day-content' }, detailData.content)),           // 컨텐츠
             div({ className: 'history-repair' }, '수정'),
             div({ className: 'history-day-item-right' },
-                div({ className: 'payment' }, detailData.name),                      // 결제수단
+                div({ className: 'payment' }, detailData.paymentMethodName),                      // 결제수단
                 div({ className: `${detailData.categoryType === "수입" ? "income" : "outcome"}-money` }, detailData.money)));            // 금액
     }
 

--- a/frontend/src/component/history/history.scss
+++ b/frontend/src/component/history/history.scss
@@ -47,6 +47,8 @@
           justify-content: space-between;
           align-items: baseline;
 
+          
+
           .history-day-item-left {
             display: flex;
             flex-direction: row;
@@ -102,5 +104,12 @@
         border-bottom: 1px solid darkgray;
       }
     }
+  }
+}
+
+.input-money-wrap {
+
+  .input-money-text {
+    text-align: right;
   }
 }

--- a/frontend/src/model.js
+++ b/frontend/src/model.js
@@ -1,0 +1,3 @@
+export default class Model {
+
+}

--- a/frontend/src/utils/handleElement.js
+++ b/frontend/src/utils/handleElement.js
@@ -81,8 +81,8 @@ export function makeElement(type, firstChild, ...otherChildren) {
         Object.keys(firstChild).forEach((propertyName) => {
             if (propertyName in element) {
                 /**
-				 * key : property name
-				 * value : property value
+                 * key : property name
+                 * value : property value
 				 */
                 const value = firstChild[propertyName];
                 if (propertyName === 'style') {
@@ -94,7 +94,7 @@ export function makeElement(type, firstChild, ...otherChildren) {
                     propertyName === 'className' || propertyName === 'draggable' ||
                     propertyName === 'disabled' || propertyName === 'placeholder' ||
                     propertyName === 'maxLength' || propertyName === 'value' ||
-                    propertyName === 'size'
+                    propertyName === 'size' || propertyName === 'hidden' || propertyName === 'selected'
                 ) {
                     element[propertyName] = value;
                 }

--- a/frontend/src/utils/handleElement.js
+++ b/frontend/src/utils/handleElement.js
@@ -89,7 +89,13 @@ export function makeElement(type, firstChild, ...otherChildren) {
                     setStyles(element, value);
                 } else if (propertyName === 'dataset') {
                     setDataAttributes(element, value);
-                } else if (typeof value === 'function' || propertyName === 'className' || propertyName === 'draggable' || propertyName === 'disabled' || propertyName === 'placeholder' || propertyName === 'maxLength') {
+                } else if (
+                    typeof value === 'function' || propertyName === 'type' ||
+                    propertyName === 'className' || propertyName === 'draggable' ||
+                    propertyName === 'disabled' || propertyName === 'placeholder' ||
+                    propertyName === 'maxLength' || propertyName === 'value' ||
+                    propertyName === 'size'
+                ) {
                     element[propertyName] = value;
                 }
             } else {

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -4,6 +4,7 @@ import loginRouter from "./login/loginRouter";
 import authRouter from "./auth/authRouter";
 import userRouter from "./user/userRouter";
 import transactionRouter from "./record/recordRouter";
+import paymentRouter from "./payment/paymentRouter";
 
 const router = express.Router();
 const PUBLIC_PATH = path.join(__dirname, "..", "public");
@@ -15,5 +16,6 @@ router.use("/api/login", loginRouter);
 router.use("/api/auth", authRouter);
 router.use("/api/user", userRouter);
 router.use("/api/transaction", transactionRouter);
+router.use("/api/payment", paymentRouter);
 
 export default router;

--- a/server/src/api/payment/paymentController.ts
+++ b/server/src/api/payment/paymentController.ts
@@ -1,0 +1,11 @@
+import { Request, Response, NextFunction } from "express";
+import query from "../../db/query";
+import db from "../../db/mysql";
+
+export default {
+    getPaymentMethod: async function (req: Request, res: Response, next: NextFunction) {
+        const { memberNo } = req.params;
+        const records = await db.selectData(query.SELECT_PAYMENT_METHOD_TB, [memberNo]);
+        res.status(200).json(records);
+    }
+};

--- a/server/src/api/payment/paymentRouter.ts
+++ b/server/src/api/payment/paymentRouter.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import paymentController from "./paymentController";
+
+const router = Router();
+
+router.get("/method/:memberNo/", paymentController.getPaymentMethod);
+
+export default router;

--- a/server/src/db/query.ts
+++ b/server/src/db/query.ts
@@ -32,6 +32,8 @@ const CREATE_PAYMENT_METHOD_TB = `
 
 const INSERT_PAYMENT_METHOD_TB = `INSERT INTO payment_method_tb(name, member_no) VALUES(?, ?);`;
 
+const SELECT_PAYMENT_METHOD_TB = `select no, name as paymentMethodName from payment_method_tb where member_no = ? and is_deleted = 0`;
+
 // ================================== category_tb =========================
 const CREATE_CATEGORY_TB = `
     CREATE TABLE IF NOT EXISTS category_tb (
@@ -74,7 +76,10 @@ const UPDATE_RECORD_TB = `
 `;
 
 const SELECT_RECORD_INFO = `
-    select payment_at as paymentAt, member_tb.email, category_tb.type as categoryType, category_tb.name, payment_method_tb.name, money, content 
+    select 
+        payment_at as paymentAt, member_tb.email, category_tb.type as categoryType, 
+        category_tb.name as categoryName, payment_method_tb.name as paymentMethodName, 
+        money, content 
     from record_tb
         INNER JOIN member_tb on record_tb.member_no = member_tb.no
         inner join payment_method_tb on payment_method_tb.no = record_tb.payment_method_no
@@ -110,6 +115,7 @@ export default {
     SELECT_MEMBER_TB_EMAIL_PASSWORD,
     CREATE_PAYMENT_METHOD_TB,
     INSERT_PAYMENT_METHOD_TB,
+    SELECT_PAYMENT_METHOD_TB,
     CREATE_CATEGORY_TB,
     INSERT_CATEGORY_TB,
     CREATE_RECORD_TB,


### PR DESCRIPTION
수정되어야 하는 항목이 많았고 서로 다른 영역, 겹치는 영역을 하고 있어서 동기화를 위해 현재까지 작업 PR

- 입력 화면에서 3자리마다 , 적용하고 15자리수까지 제한
- 수입 지출 버튼에 이벤트를 달아서 서로 다른 select 엘리먼트가 적용되도록 수정
- 기존 쿼리에서 카테고리, 결제 수단 이름을 동일하게 했던 부분을 수정
- 각 유저마다 등록된 결제수단 정보를 서버로부터 가져와서 거래내역 셀렉트 엘리먼트에 반영
