### PR TITLE
Frontend/#35/model

### DIFF
--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -1,7 +1,10 @@
 import './app.scss';
 import Router from './router';
+import Model from './model';
+
 import { Header } from './component/header/header';
 import { Body } from './component/body/body';
+
 import { ListTab, MonthTab } from './component/body/tap/tab';
 
 import HistoryComponent from './app/app';
@@ -18,10 +21,16 @@ const DATA = [
     { name: "미분류", percent: "2%", money: 9000 },
 ];
 
+// 모델 생성
+const model = new Model();
+window.model = model;
+
 // 라우터 생성
 const app = document.querySelector('#app'); // 최상단 노드
 const router = new Router(app);
 window.router = router;
+
+
 
 // 전역 헤더, 탭 생성
 const header = new Header();

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -39,7 +39,7 @@ const chartComponent = new ChartComponent();
 chartComponent.setData(DATA);
 
 // 첫화면 설정
-router.setPath('/', historyComponent);
+router.setPath('/', calenderComponent);
 
 // 그 외 경로 설정
 router.setPath('/history', historyComponent);

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -27,7 +27,7 @@ window.model = model;
 
 // 라우터 생성
 const app = document.querySelector('#app'); // 최상단 노드
-const router = new Router(app);
+const router = new Router(app, model);
 window.router = router;
 
 

--- a/frontend/src/component/body/body.js
+++ b/frontend/src/component/body/body.js
@@ -21,15 +21,15 @@ export class Body {
         this.mutableComponents = components;
     }
 
-    createBody() {
+    createBody(monthModel) {
         const commons = this.commonComponents.map(component => component.render());
-        const mutable = this.mutableComponents.map(component => component.render());
+        const mutable = this.mutableComponents.map(component => component.render(monthModel));
         appendArray(this.bodySection, [...commons, ...mutable]);
     }
 
-    render() {
+    render(monthModel) {
         this.reset();
-        this.createBody();
+        this.createBody(monthModel);
 
         return this.bodySection;
     }

--- a/frontend/src/component/body/input/input.js
+++ b/frontend/src/component/body/input/input.js
@@ -3,7 +3,6 @@ import { createEl } from '../../../utils/createElement';
 import { appendArray } from '../../../utils/handleElement';
 import { clickDeleteInputInfoBtn, clickIncomeBtn, clickOutcomeBtn, keyupMoneyInput, clickSubmitBtn } from './inputHandler.js';
 import { div, input, select, option } from '../../../utils/element';
-import { func } from './inputHandler';
 import api from '../../../utils/api';
 
 

--- a/frontend/src/component/body/tap/tab.js
+++ b/frontend/src/component/body/tap/tab.js
@@ -1,8 +1,6 @@
 import './tab.scss';
 import { createEl } from '../../../utils/createElement';
 import { appendArray } from '../../../utils/handleElement';
-import { clickHistory, clickCalender, clickStatistics, clickLeftArrow, clickRightArrow } from './tabHandler';
-import { Calender } from "../../calender/calender";
 
 export class ListTab {
     constructor(router) {
@@ -67,30 +65,26 @@ export class MonthTab {
 
     createMonthTapNodes() {
         this.monthTapWrap = createEl('div', 'month-tap-wrap', '', {});
-        this.leftArrow = createEl('div', 'left-arrow prev', '⇦', { onclick: clickLeftArrow });
         this.selectedMonth = createEl('div', 'selected-month date', `${this.currentMonth}`, {});
 
-        this.rightArrow = createEl('div', 'right-arrow next', '⇨', { onclick: clickRightArrow });
+        this.leftArrow = createEl('div', 'left-arrow prev', '⇦', {});
+        this.rightArrow = createEl('div', 'right-arrow next', '⇨', {});
 
         appendArray(this.monthTapWrap, [this.leftArrow, this.selectedMonth, this.rightArrow]);
         appendArray(this.monthTapSection, [this.monthTapWrap]);
 
         this.leftArrow.addEventListener("click", e => {
-            if(this.currentMonth === 1) return;
-            const calendarComponent = this.router.viewMap.get('/calender');
-            calendarComponent.moveMonth(-1);
-            calendarComponent.renderCalendar();
+            if (this.currentMonth === 1) return;
             this.currentMonth--;
             this.render();
+            window.model.decreaseMonth();
         });
 
         this.rightArrow.addEventListener("click", e => {
-            if(this.currentMonth === 12) return;
-            const calendarComponent = this.router.viewMap.get('/calender');
-            calendarComponent.moveMonth(1);
-            calendarComponent.renderCalendar();
+            if (this.currentMonth === 12) return;
             this.currentMonth++;
             this.render();
+            window.model.increaseMonth();
         });
     }
 

--- a/frontend/src/component/body/tap/tabHandler.js
+++ b/frontend/src/component/body/tap/tabHandler.js
@@ -19,7 +19,7 @@ export const clickStatistics = function (e) {
 };
 
 export const clickLeftArrow = function (e) {
-    console.log(e.target.value)
+    console.log("left : " + e.target)
 };
 
 export const clickRightArrow = function (e) {

--- a/frontend/src/component/body/tap/tabHandler.js
+++ b/frontend/src/component/body/tap/tabHandler.js
@@ -1,5 +1,4 @@
 
-
 export const clickHistory = function (e) {
     const path = getCurrentPath(e, '/history');
     const state = getStates(path);
@@ -19,9 +18,11 @@ export const clickStatistics = function (e) {
 };
 
 export const clickLeftArrow = function (e) {
-    console.log("left : " + e.target)
+    console.log("left : " + e.target);
+    model.deacreaseMonth();
 };
 
 export const clickRightArrow = function (e) {
     console.log("rightArrow");
+    model.increaseMonth();
 };

--- a/frontend/src/component/calender/calender.js
+++ b/frontend/src/component/calender/calender.js
@@ -12,10 +12,7 @@ export class Calender {
         this.incomeMoneyMap = new Map();
         this.incomeMoneyMap = json.incomeMoneyObj;
         this.outcomeMoneyMap = new Map();
-
-    }
-    setData(data) {
-        this.data = data;
+        this.monthModel;
     }
     moveMonth(value) {
         this.date.setMonth(this.date.getMonth() + value);
@@ -28,84 +25,83 @@ export class Calender {
     getApiDayData() {
         // todo: api요청으로 현재 월을 보내서 현재 월에 대한 모든 날짜의 수입, 지출 받아오기
         // todo: 받아온 데이터를 incomeMoneyMap (key:일수,val:수입금액), outcomeMoneyMap 에 넣기(key:일수,val:지출금액)
-         }
+    }
 
 
 
-    renderCalendar() {
-        const date = this.date;
-        date.setDate(1);
+    renderCalendar(monthModel) {
+
+        const year = monthModel.year;
+        const month = monthModel.month - 1;
+        const date = new Date(year, month, 1);
+
 
         const monthDays = this.calenderSection.querySelector(".days");
 
-        const lastDay = new Date(
-            date.getFullYear(),
-            date.getMonth() + 1,
-            0
-        ).getDate();
-
-        const prevLastDay = new Date(
-            date.getFullYear(),
-            date.getMonth(),
-            0
-        ).getDate();
+        const lastDay = new Date(year, month + 1, 0).getDate();
+        const prevLastDay = new Date(year, month, 0).getDate();
 
         const firstDayIndex = date.getDay();
-
-        const lastDayIndex = new Date(
-            date.getFullYear(),
-            date.getMonth() + 1,
-            0
-        ).getDay();
+        const lastDayIndex = new Date(year, month + 1, 0).getDay();
 
         const nextDays = 7 - lastDayIndex - 1;
 
-        const months = [
-            "1월",
-            "2월",
-            "3월",
-            "4월",
-            "5월",
-            "6월",
-            "7월",
-            "8월",
-            "9월",
-            "10월",
-            "11월",
-            "12월",
-        ];
-
         let days = '';
 
-        for (let x = firstDayIndex; x > 0; x--) {
-            days += `<div class="prev-date day">${prevLastDay - x + 1}</div>`;
+        days += this.createPrevDays(prevLastDay, firstDayIndex);
+        days += this.createCurrentDays(lastDay, monthModel);
+        days += this.createNextDays(nextDays);
+
+        monthDays.innerHTML = days;
+    }
+
+    createPrevDays(prevLastDay, firstDayIndex) {
+        console.log(prevLastDay, firstDayIndex);
+        let prevDay = prevLastDay - firstDayIndex + 1;
+        let daysInnerHtml = "";
+        for (prevDay; prevDay <= prevLastDay; prevDay++) {
+            daysInnerHtml += `<div class="prev-date day">${prevDay}</div>`;
         }
+        return daysInnerHtml;
+    }
+    createCurrentDays(lastDay, monthModel) {
+        console.log(monthModel);
+        let daysInnerHtml = "";
+        const todayDate = new Date();
+        const [currentMonth, currentDay] = [todayDate.getMonth() + 1, todayDate.getDate()];
+
+        const drawingMonth = monthModel.month;
+        let totalIncome = 0, totalOutcome = 0;
 
         for (let i = 1; i <= lastDay; i++) {
-            if (
-                i === new Date().getDate() &&
-                date.getMonth() === new Date().getMonth()
-            ) {
-                days += `<div class="today day">${i}
-<div class="day-in-put-money">
-<div class="day-income">+ ${this.incomeMoneyMap[i]}</div>
-<div class="day-outcome">-4,000원</div>
-</div>
-</div>`;
+            const { totalIncome, totalOutcome } = monthModel.getTotal(i);
+            if (drawingMonth === currentMonth && i === currentDay) {
+                daysInnerHtml += `<div class="today day">${i}
+                        <div class="day-in-put-money">
+                        <div class="day-income">${totalIncome || "ㅤ"}</div>
+                        <div class="day-outcome">${totalOutcome || "ㅤ"}</div>
+                        </div>
+                        </div>`;
             } else {
-                days += `<div class="other-day day">${i}
-<div class="day-in-put-money">
-<div class="day-income">+ ${this.incomeMoneyMap[i]}</div>
-<div class="day-outcome">-4,000원</div>
-</div>
-</div>`;
+                daysInnerHtml += `<div class="other-day day">${i}
+                        <div class="day-in-put-money">
+                        <div class="day-income">${totalIncome || "ㅤ"}</div>
+                        <div class="day-outcome">${totalOutcome || "ㅤ"}</div>
+                        </div>
+                        </div>`;
             }
         }
+        return daysInnerHtml;
+    }
+    createNextDays(nextDays) {
+        let daysInnerHtml = "";
 
         for (let j = 1; j <= nextDays; j++) {
-            days += `<div class="next-date day">${j}</div>`;
-            monthDays.innerHTML = days;
+            daysInnerHtml += `<div class="next-date day">${j}</div>`;
         }
+
+        return daysInnerHtml;
+
     }
 
     createCalenderWrap() {
@@ -127,10 +123,10 @@ export class Calender {
         appendArray(this.calenderSection, [this.createCalenderWrap()]);
     }
 
-    render() {
+    render(monthData) {
         this.reset();
         this.createCalender();
-        this.renderCalendar();
+        this.renderCalendar(monthData);
         return this.calenderSection;
     }
 }

--- a/frontend/src/component/history/history.js
+++ b/frontend/src/component/history/history.js
@@ -43,7 +43,6 @@ export class History {
     }
 
     setData(data) {
-        console.log("adf", data);
         this.data = data;
     }
 

--- a/frontend/src/model.js
+++ b/frontend/src/model.js
@@ -1,3 +1,66 @@
-export default class Model {
+import api from './utils/api';
 
+export default class Model {
+    constructor() {
+        this.selectedMonth = (new Date()).getMonth() + 1;
+        this.subscribers = [];
+        this.store = new Map;
+        this.setMonthData(this.selectedMonth);
+    }
+    getMonthData(month) {
+        if (!this.store.has(month)) this.setMonthData(month);
+        return this.store.get(month);
+    }
+    async setMonthData(month) {
+        const oneMonthData = await this.getServerMonthData(month);
+        this.store.set(month, oneMonthData);
+    }
+    async getServerMonthData(month) {
+        const data = await api.get('http://localhost:3000/api/transaction/abc@abc.com/7').then(res => res.json());
+        const oneMonthData = new MonthModel(2020, month, data);
+        return oneMonthData;
+    }
+    unsubscribe() {
+
+    }
+    subscribe(component) {
+        this.subscribers.push(component);
+    }
+    notify() {
+        const data = this.getMonthData(this.selectedMonth);
+        this.subscribers.forEach(subscriber => subscriber.render(data));
+    }
+}
+
+class MonthModel {
+    constructor(year, month, data) {
+        this.year = year;
+        this.month = month;
+        this.data = new Map;
+        this.initData(data);
+    }
+    initData(data) {
+        let oneDay;
+        let preDate = -1000;
+        data.forEach(one => {
+            const oneDate = new Date(one.paymentAt);
+            if (preDate !== oneDate.getDate()) {
+                oneDay = {
+                    paymentAt: one.paymentAt,
+                    totalIncome: 0,
+                    totalOutcome: 0,
+                    items: [],
+                };
+                preDate = oneDate.getDate()
+                this.data.set(preDate, oneDay);
+            }
+            const { categoryType, categoryName, paymentMethodName, money, content } = one;
+            if (categoryType === "지출") {
+                oneDay.totalOutcome += parseInt(money);
+            } else {
+                oneDay.totalIncome += parseInt(money);
+            }
+            oneDay.items.push({ categoryType, categoryName, paymentMethodName, money, content });
+        });
+    }
 }

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -1,7 +1,8 @@
 
 
 export default class Router {
-    constructor(appElement) {
+    constructor(appElement, model) {
+        this.model = model;
         this.appElement = appElement;
         this.viewMap = new Map;
         this.bodyComponent = null;
@@ -27,11 +28,13 @@ export default class Router {
     pushState(path, state) {
         history.pushState(state, '', path);
     }
-    popStateHandler({ state }) {
+    async popStateHandler({ state }) {
+        const monthData = await this.model.getMonthData();
         const targetView = location.pathname;
         const viewComponent = this.viewMap.get(targetView);
+        this.model.subscribe(viewComponent);
         this.bodyComponent.setMutableComponents(viewComponent);
         app.innerHTML = "";
-        app.appendChild(this.bodyComponent.render());
+        app.appendChild(this.bodyComponent.render(monthData));
     }
 }

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -3,41 +3,29 @@ export default {
     get: function (url, data) {
         return fetch(url, {
             method: 'GET',
-            headers: {
-                'Content-Type': 'application/json'
-            },
+            headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(data)
-        })
-
+        });
     },
     post: function (url, data) {
         return fetch(url, {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
+            headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(data)
-        })
-
+        });
     },
     put: function (url, data) {
         return fetch(url, {
             method: 'PUT',
-            headers: {
-                'Content-Type': 'application/json'
-            },
+            headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(data)
-        })
-
+        });
     },
     delete: function (url, data) {
         return fetch(url, {
             method: 'DELETE',
-            headers: {
-                'Content-Type': 'application/json'
-            },
+            headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(data)
-        })
-
+        });
     }
 }

--- a/server/src/api/payment/paymentRouter.ts
+++ b/server/src/api/payment/paymentRouter.ts
@@ -4,5 +4,7 @@ import paymentController from "./paymentController";
 const router = Router();
 
 router.get("/method/:memberNo/", paymentController.getPaymentMethod);
+router.post("/method/:memberNo/", () => { });
+router.delete("/method/:memberNo/", () => { });
 
 export default router;

--- a/server/src/api/record/recordRouter.ts
+++ b/server/src/api/record/recordRouter.ts
@@ -4,5 +4,6 @@ import recordController from "./recordController";
 const router = Router();
 
 router.get("/:email/:month", recordController.getMonthRecord);
+router.post("/:email/:month", () => { });  // 개별 내역 추가
 
 export default router;


### PR DESCRIPTION
### 모델 생성
- 달력, 모델, 라우터를 연결
- 월 증가, 감소에 따라서 해당하는 데이터를 모델에서 받아온다.

### 달력, 모델, 라우터 연결
- 전역으로 사용되는 모델 객체를 생성
- 현재는 전역으로 쓴다는 의미로 window.model에 적용
- 월을 증가, 감소 할때마다 데이터를 서버에서 가져오고 캐시
- setMonthData 변경때마다 subscriber에게 render()를 호출

### record, history api 추가

`POST : /api/record/:email/:month`       : 해당 월의 거래내역 추가          
`POST : /api/payment/method/:memberNo/`         : 사용자의 결제수단 추가       
`DELETE : /api/payment/method/:memberNo/`       : 사용자의 결제수단 제거      